### PR TITLE
Fixes for ObjectDisplay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Fixed a bug where the leading new line was included for long strings.
-
+- Fixed a bug where the leading new line was included for long strings;
+- Fixed a bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would escape the space character;
 ## v0.2.9
 ### Added
 - We've added support for LuaJIT imaginary numbers which also resulted in the following being added:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug where the leading new line was included for long strings;
 - Fixed a bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would escape the space character;
+- Fixed a bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would not generate correct verbatim/long strings.
 ## v0.2.9
 ### Added
 - We've added support for LuaJIT imaginary numbers which also resulted in the following being added:

--- a/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
@@ -112,39 +112,136 @@ namespace Loretta.CodeAnalysis.Lua.SymbolDisplay
                 return true;
             }
 
-            if (NeedsEscaping(CharUnicodeInfo.GetUnicodeCategory(c)))
+            if (NeedsEscaping(c))
             {
-                replaceWith = utf8Encode ? CharUtils.EncodeCharToUtf8(c) : "\\u{" + ((int) c).ToString("x4") + "}";
+                replaceWith = utf8Encode ? CharUtils.EncodeCharToUtf8(c) : "\\u{" + ((int) c).ToString("X4") + "}";
                 return true;
             }
 
             return false;
         }
 
-        private static bool NeedsEscaping(UnicodeCategory category)
+        private static bool NeedsEscaping(char ch)
         {
-            // Some characters will probably pass that shouldn't and some that should won't,
-            // but this is easier than having a huge switch with all characters that are
-            // "printable" or "readable".
-            // We list a few of the the most common characters but the others will pass
-            // through the flagset check.
-            const uint categoryFlagSet = (1U << (int) UnicodeCategory.ClosePunctuation)
-                                           | (1U << (int) UnicodeCategory.ConnectorPunctuation)
-                                           | (1U << (int) UnicodeCategory.CurrencySymbol)
-                                           | (1U << (int) UnicodeCategory.DashPunctuation)
-                                           | (1U << (int) UnicodeCategory.DecimalDigitNumber)
-                                           | (1U << (int) UnicodeCategory.FinalQuotePunctuation)
-                                           | (1U << (int) UnicodeCategory.InitialQuotePunctuation)
-                                           | (1U << (int) UnicodeCategory.LetterNumber)
-                                           | (1U << (int) UnicodeCategory.LowercaseLetter)
-                                           | (1U << (int) UnicodeCategory.MathSymbol)
-                                           | (1U << (int) UnicodeCategory.OpenPunctuation)
-                                           | (1U << (int) UnicodeCategory.OtherLetter)
-                                           | (1U << (int) UnicodeCategory.OtherNumber)
-                                           | (1U << (int) UnicodeCategory.OtherPunctuation)
-                                           | (1U << (int) UnicodeCategory.TitlecaseLetter)
-                                           | (1U << (int) UnicodeCategory.UppercaseLetter);
-            return !CharUtils.IsCategoryInSet(categoryFlagSet, category);
+            switch (ch)
+            {
+                // ASCII characters that never need escaping.
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case 'a':
+                case 'b':
+                case 'c':
+                case 'd':
+                case 'e':
+                case 'f':
+                case 'g':
+                case 'h':
+                case 'i':
+                case 'j':
+                case 'k':
+                case 'l':
+                case 'm':
+                case 'n':
+                case 'o':
+                case 'p':
+                case 'q':
+                case 'r':
+                case 's':
+                case 't':
+                case 'u':
+                case 'v':
+                case 'w':
+                case 'x':
+                case 'y':
+                case 'z':
+                case 'A':
+                case 'B':
+                case 'C':
+                case 'D':
+                case 'E':
+                case 'F':
+                case 'G':
+                case 'H':
+                case 'I':
+                case 'J':
+                case 'K':
+                case 'L':
+                case 'M':
+                case 'N':
+                case 'O':
+                case 'P':
+                case 'Q':
+                case 'R':
+                case 'S':
+                case 'T':
+                case 'U':
+                case 'V':
+                case 'W':
+                case 'X':
+                case 'Y':
+                case 'Z':
+                case '_':
+                case ' ':
+                case '`':
+                case '!':
+                case '@':
+                case '#':
+                case '%':
+                case '&':
+                case '*':
+                case '-':
+                case '=':
+                case '+':
+                case '§':
+                case '(':
+                case ')':
+                case '[':
+                case ']':
+                case '{':
+                case '}':
+                case '|':
+                case '/':
+                case ';':
+                case ':':
+                case '<':
+                case '>':
+                case ',':
+                case '.':
+                case '?':
+                    return false;
+
+                default:
+                    // Some characters will probably pass that shouldn't and some that should won't,
+                    // but this is easier than having a huge switch with all characters that are
+                    // "printable" or "readable".
+                    // We list a few of the the most common characters but the others will pass
+                    // through the flagset check.
+                    const uint categoryFlagSet = (1U << (int) UnicodeCategory.ClosePunctuation)
+                                                   | (1U << (int) UnicodeCategory.ConnectorPunctuation)
+                                                   | (1U << (int) UnicodeCategory.CurrencySymbol)
+                                                   | (1U << (int) UnicodeCategory.DashPunctuation)
+                                                   | (1U << (int) UnicodeCategory.DecimalDigitNumber)
+                                                   | (1U << (int) UnicodeCategory.FinalQuotePunctuation)
+                                                   | (1U << (int) UnicodeCategory.InitialQuotePunctuation)
+                                                   | (1U << (int) UnicodeCategory.LetterNumber)
+                                                   | (1U << (int) UnicodeCategory.LowercaseLetter)
+                                                   | (1U << (int) UnicodeCategory.MathSymbol)
+                                                   | (1U << (int) UnicodeCategory.OpenPunctuation)
+                                                   | (1U << (int) UnicodeCategory.OtherLetter)
+                                                   | (1U << (int) UnicodeCategory.OtherNumber)
+                                                   | (1U << (int) UnicodeCategory.OtherPunctuation)
+                                                   | (1U << (int) UnicodeCategory.TitlecaseLetter)
+                                                   | (1U << (int) UnicodeCategory.UppercaseLetter);
+                    return !CharUtils.IsCategoryInSet(categoryFlagSet, CharUnicodeInfo.GetUnicodeCategory(ch));
+            }
         }
 
         /// <summary>

--- a/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
@@ -316,6 +316,9 @@ namespace Loretta.CodeAnalysis.Lua.SymbolDisplay
             Span<char> startBuffer = stackalloc char[bufferSize], endBuffer = stackalloc char[bufferSize];
             var idx = 1;
 
+            (startBuffer[0], startBuffer[1]) = ('[', '[');
+            (endBuffer[0], endBuffer[1]) = (']', ']');
+
             while (value.Contains(startBuffer[..(idx + 1)], StringComparison.Ordinal) || value.Contains(endBuffer[..(idx + 1)], StringComparison.Ordinal))
             {
                 if (idx >= bufferSize - 1)
@@ -329,7 +332,7 @@ namespace Loretta.CodeAnalysis.Lua.SymbolDisplay
                 idx++;
             }
 
-            startDelimiter = startBuffer.ToString(); endDelimiter = endBuffer.ToString();
+            startDelimiter = startBuffer[..(idx + 1)].ToString(); endDelimiter = endBuffer[..(idx + 1)].ToString();
             return true;
         }
 

--- a/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
@@ -6,6 +6,44 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.SymbolDisplay
 {
     public sealed class ObjectDisplayTests
     {
+        [Fact]
+        public void ObjectDisplay_FormatLiteralString_ThrowsExceptionWhenValueIsNull() =>
+            Assert.Throws<ArgumentNullException>(() => ObjectDisplay.FormatLiteral(null!, ObjectDisplayOptions.None));
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralString_OnlyAddsQuotesWhenAskedTo()
+        {
+            var noQuotes = ObjectDisplay.FormatLiteral("hello", ObjectDisplayOptions.None);
+            var withQuotes = ObjectDisplay.FormatLiteral("hello", ObjectDisplayOptions.UseQuotes);
+
+            Assert.False(noQuotes.StartsWith("\"") || noQuotes.EndsWith("\""), "No quotes output has quotes.");
+            Assert.True(withQuotes.StartsWith("\"") || withQuotes.EndsWith("\""), "With quotes output has no quotes.");
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralString_OnlyEscapesNonPrintableCharactersWhenAskedTo()
+        {
+            const string input = "\0\t\r\n";
+
+            var unescaped = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.None);
+            var escaped = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.EscapeNonPrintableCharacters);
+
+            Assert.Equal(input, unescaped);
+            Assert.Equal(@"\0\t\r\n", escaped);
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralString_OnlyEscapesWithUtf8WhenAskedTo()
+        {
+            const string input = "\uFEFF";
+
+            var unescaped = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.EscapeNonPrintableCharacters);
+            var escaped = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.EscapeWithUtf8);
+
+            Assert.Equal(@"\u{FEFF}", unescaped);
+            Assert.Equal(@"\xEF\xBB\xBF", escaped);
+        }
+
         [Theory]
         [InlineData(
             """

--- a/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
@@ -1,4 +1,6 @@
+using System.Numerics;
 using Loretta.CodeAnalysis.Lua.SymbolDisplay;
+using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.Test.Utilities;
 using Xunit;
 
@@ -94,6 +96,56 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.SymbolDisplay
             var output = ObjectDisplay.FormatLiteral(input);
 
             Assert.Equal(expected, output);
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralDouble_OutputsHexadecimalFloatsWhenAskedTo()
+        {
+            const double input = 255.255;
+
+            var @decimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.None);
+            var hexadecimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseHexadecimalNumbers);
+
+            Assert.Equal("255.255", @decimal);
+            // We don't want to indirectly test HexFloat here so we just use its output.
+            Assert.Equal(HexFloat.DoubleToHexString(input), hexadecimal);
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralLong_OutputsHexadecimalIntegersWhenAskedTo()
+        {
+            const long input = 65535;
+
+            var @decimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.None);
+            var hexadecimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseHexadecimalNumbers);
+
+            Assert.Equal("65535", @decimal);
+            Assert.Equal("0xFFFF", hexadecimal);
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralULong_OutputsHexadecimalIntegersWhenAskedTo()
+        {
+            const ulong input = 65535;
+
+            var @decimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.None);
+            var hexadecimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseHexadecimalNumbers);
+
+            Assert.Equal("65535ULL", @decimal);
+            Assert.Equal("0xFFFFULL", hexadecimal);
+        }
+
+        [Fact]
+        public void ObjectDisplay_FormatLiteralComplex_OutputsHexadecimalNumbersWhenAskedTo()
+        {
+            var input = new Complex(0, 255.255);
+
+            var @decimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.None);
+            var hexadecimal = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseHexadecimalNumbers);
+
+            Assert.Equal("255.255i", @decimal);
+            // We don't want to indirectly test HexFloat here so we just use its output.
+            Assert.Equal(HexFloat.DoubleToHexString(input.Imaginary) + 'i', hexadecimal);
         }
     }
 }

--- a/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
@@ -6,6 +6,38 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.SymbolDisplay
 {
     public sealed class ObjectDisplayTests
     {
+        [Theory]
+        [InlineData(
+            """
+            a
+            a
+            a
+            """,
+            """
+            [[a
+            a
+            a]]
+            """
+        )]
+        [InlineData(
+            """
+            [[a
+            a
+            a]]
+            """,
+            """
+            [=[[[a
+            a
+            a]]]=]
+            """
+        )]
+        public void ObjectDisplay_FormatLiteralString_OutputsLongStringWhenQuotesWereRequestedNewLineIsPresentAndEscapingWasNotRequested(string input, string expected)
+        {
+            var output = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseQuotes);
+
+            Assert.Equal(expected, output);
+        }
+
         [Fact, WorkItem(89, "https://github.com/LorettaDevs/Loretta/issues/89")]
         public void ObjectDisplay_FormatLiteralString_DoesNotEscapeSpace()
         {

--- a/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
@@ -85,5 +85,15 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.SymbolDisplay
 
             Assert.Equal("\"hello there\"", output);
         }
+
+        [Theory]
+        [InlineData(true, "true")]
+        [InlineData(false, "false")]
+        public void ObjectDisplay_FormatLiteralBool_ReturnsTheCorrectValues(bool input, string expected)
+        {
+            var output = ObjectDisplay.FormatLiteral(input);
+
+            Assert.Equal(expected, output);
+        }
     }
 }

--- a/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SymbolDisplay/ObjectDisplayTests.cs
@@ -1,0 +1,19 @@
+using Loretta.CodeAnalysis.Lua.SymbolDisplay;
+using Loretta.Test.Utilities;
+using Xunit;
+
+namespace Loretta.CodeAnalysis.Lua.UnitTests.SymbolDisplay
+{
+    public sealed class ObjectDisplayTests
+    {
+        [Fact, WorkItem(89, "https://github.com/LorettaDevs/Loretta/issues/89")]
+        public void ObjectDisplay_FormatLiteralString_DoesNotEscapeSpace()
+        {
+            const string input = "hello there";
+
+            var output = ObjectDisplay.FormatLiteral(input, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters);
+
+            Assert.Equal("\"hello there\"", output);
+        }
+    }
+}


### PR DESCRIPTION
Fixed the following issues:
- Bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would escape the space character;
- Bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would not generate correct verbatim/long strings.

Fixes #89.