### PR TITLE
Fix intersection and union types having bitwise operator not supported errors in Luau

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the leading new line was included for long strings;
 - Fixed a bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would escape the space character;
 - Fixed a bug where `ObjectDisplay.FormatLiteral(string value, ObjectDisplayOptions options)` would not generate correct verbatim/long strings;
-- Fixed parsing of anonymous functions that had type parameters.
+- Fixed parsing of anonymous functions that had type parameters;
+- Fixed union and intersection types having errors for bitwise operators generated in them.
 
 ## v0.2.9
 ### Added

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -814,6 +814,11 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         SyntaxKind.GreaterThanGreaterThanToken,
                         trailingToken.GetTrailingTrivia());
                 }
+                else if (operatorKind is SyntaxKind.PipeToken or SyntaxKind.AmpersandToken
+                         && !Options.SyntaxOptions.AcceptBitwiseOperators)
+                {
+                    operatorToken = AddError(operatorToken, ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
+                }
 
                 var kind = SyntaxFacts.GetBinaryExpression(operatorToken.Kind).Value;
                 var right = ParseBinaryExpression(newPrecedence);

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -487,8 +487,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
                     else
                     {
-                        if (!_options.SyntaxOptions.AcceptBitwiseOperators)
-                            AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                         info.Kind = SyntaxKind.AmpersandToken;
                     }
                     break;
@@ -502,8 +500,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
                     else
                     {
-                        if (!_options.SyntaxOptions.AcceptBitwiseOperators)
-                            AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                         info.Kind = SyntaxKind.PipeToken;
                     }
                     break;

--- a/src/Compilers/Lua/Test/Portable/Parsing/RegressionTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/RegressionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Loretta.CodeAnalysis.Text;
+using Loretta.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -130,5 +131,27 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Parsing
 
             Assert.True(firstIdent.IsEquivalentTo(secondIdent));
         }
+
+        [Fact, WorkItem(100, "https://github.com/LorettaDevs/Loretta/issues/100")]
+        public void LanguageParser_WhenParsingIntersectionTypes_DoNotGenerateBitwiseOperatorNotSupportedErrors() =>
+            ParseAndValidate("type T = A & B", LuaSyntaxOptions.Luau);
+
+        [Fact, WorkItem(100, "https://github.com/LorettaDevs/Loretta/issues/100")]
+        public void LanguageParser_WhenParsingUnionTypes_DoNotGenerateBitwiseOperatorNotSupportedErrors() =>
+            ParseAndValidate("type T = A | B", LuaSyntaxOptions.Luau);
+
+        [Fact, WorkItem(100, "https://github.com/LorettaDevs/Loretta/issues/100")]
+        public void LanguageParser_WhenParsingBitwiseAndExpressions_GeneratesBitwiseOperatorNotSupportedErrors() =>
+            ParseAndValidate("local x = y & z", LuaSyntaxOptions.Luau,
+                // (1,13): error LUA0021: Bitwise operators are not supported in this lua version
+                // local x = y & z
+                Diagnostic(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion, "&").WithLocation(1, 13));
+
+        [Fact, WorkItem(100, "https://github.com/LorettaDevs/Loretta/issues/100")]
+        public void LanguageParser_WhenParsingBitwiseOrExpressions_GeneratesBitwiseOperatorNotSupportedErrors() =>
+            ParseAndValidate("local x = y | z", LuaSyntaxOptions.Luau,
+                // (1,13): error LUA0021: Bitwise operators are not supported in this lua version
+                // local x = y | z
+                Diagnostic(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion, "|").WithLocation(1, 13));
     }
 }


### PR DESCRIPTION
Fixes #100.