### PR TITLE
Fix NormalizeWhitespace not inserting spaces between expression list arguments.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed `ContainedScopes` not being populated.
+- Fixed NormalizeWhitespace not inserting spaces between expression list arguments.
 
 ## v0.2.10
 ### Added

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
@@ -957,6 +957,19 @@ namespace Loretta.CodeAnalysis.Lua.Syntax
             return base.VisitMethodCallExpression(node);
         }
 
+        // function_argument
+        //  : expression_list_function_argument
+        //  | string_function_argument
+        //  | table_constructor_function_argument
+        //  ;
+        public override SyntaxNode? VisitExpressionListFunctionArgument(ExpressionListFunctionArgumentSyntax node)
+        {
+            foreach (var expressionSeparator in node.Expressions.GetSeparators())
+                AddSpaceAfterToken(expressionSeparator);
+
+            return base.VisitExpressionListFunctionArgument(node);
+        }
+
         // Visiting ParenthesizedExpressionSyntax is not necessary as it has no spacing.
         // Visiting ElementAccessExpressionSyntax is not necessary as it has no spacing.
         // Visiting MemberAccessExpressionSyntax is not necessary as it has no spacing.

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
@@ -957,11 +957,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax
             return base.VisitMethodCallExpression(node);
         }
 
-        // function_argument
-        //  : expression_list_function_argument
-        //  | string_function_argument
-        //  | table_constructor_function_argument
-        //  ;
+        // expression_list_function_argument
+        // : '(' (expression (',' expression)*)? ')'
+        // ;
         public override SyntaxNode? VisitExpressionListFunctionArgument(ExpressionListFunctionArgumentSyntax node)
         {
             foreach (var expressionSeparator in node.Expressions.GetSeparators())

--- a/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
@@ -1228,7 +1228,7 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests
         [WorkItem(108, "https://github.com/LorettaDevs/Loretta/issues/108")]
         public void SyntaxNormalizer_CorrectlyInsertsExpressionSpaces()
         {
-            var tree = ParseAndValidate("print(1, 2)", s_luaParseOptions);
+            var tree = ParseAndValidate("print(1,2)", s_luaParseOptions);
             var root = tree.GetRoot();
 
             AssertNormalizeCore(root, "print(1, 2)");

--- a/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using Loretta.CodeAnalysis.Lua.Test.Utilities;
+using Loretta.Test.Utilities;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1222,6 +1223,17 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests
 
             AssertNormalizeCore(type, expected);
         }
+
+        [Fact]
+        [WorkItem(108, "https://github.com/LorettaDevs/Loretta/issues/108")]
+        public void SyntaxNormalizer_CorrectlyInsertsExpressionSpaces()
+        {
+            var tree = ParseAndValidate("print(1, 2)", s_luaParseOptions);
+            var root = tree.GetRoot();
+
+            AssertNormalizeCore(root, "print(1, 2)");
+        }
+
 
         #region Class Implementation Details
 


### PR DESCRIPTION
Adds missing `VisitExpressionListFunctionArgument` method to the SyntaxNormalizer 

Fixes #108 