### PR TITLE
Remove .NET Core 3.1 Support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,24 +22,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            installDir: /usr/share/dotnet
           - os: windows-latest
-            installDir: C:\Program Files\dotnet
           - os: macos-latest
-            installDir: /Users/runner/.dotnet
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
             7.0.x
-          include-prerelease: True
-        env:
-          DOTNET_INSTALL_DIR: ${{ matrix.installDir }}
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,15 +22,11 @@ jobs:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
             7.0.x
-          include-prerelease: True
-        env:
-          DOTNET_INSTALL_DIR: C:\Program Files\dotnet
 
       - name: Setup DocFX
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/nigthly-publish.yml
+++ b/.github/workflows/nigthly-publish.yml
@@ -54,15 +54,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
             7.0.x
-          include-prerelease: True
-        env:
-          DOTNET_INSTALL_DIR: C:\Program Files\dotnet
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/stable-publish.yml
+++ b/.github/workflows/stable-publish.yml
@@ -19,15 +19,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
             7.0.x
-          include-prerelease: True
-        env:
-          DOTNET_INSTALL_DIR: C:\Program Files\dotnet
 
       - name: Install dependencies
         run: dotnet restore

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ContainedScopes` not being populated.
 - Fixed NormalizeWhitespace not inserting spaces between expression list arguments.
 
+### Removed
+- .NET Core 3.1 support has been removed as .NET Core 3.1 has officially hit EOL.
+
 ## v0.2.10
 ### Added
 - Added the following new `SyntaxFactory` overloads to partially restore compatibility with pre-typed-lua era:

--- a/build/LibraryProject.props
+++ b/build/LibraryProject.props
@@ -49,7 +49,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/build/LibraryProject.props
+++ b/build/LibraryProject.props
@@ -3,7 +3,7 @@
     <Import Project="$(MSBuildThisFileDirectory)BaseProject.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -25,7 +25,7 @@
       "globalNamespaceId": "Loretta.CodeAnalysis",
       "filter": "unwanted-filter.yml",
       "properties": {
-        "TargetFramework": "netcoreapp3.1",
+        "TargetFramework": "net6.0",
         "DocGen": "true"
       },
       "disableGitFeatures": false,

--- a/src/Compilers/Core/Portable/Loretta.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Loretta.CodeAnalysis.csproj
@@ -18,17 +18,21 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
-    <ItemGroup>
+    <!-- Packages that we need from .NET 6+ on .NET Standard 2.0 -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-        <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Nullable" Version="1.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;netstandard2.0;net472</TargetFrameworks>
         <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net6.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
+++ b/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
@@ -23,8 +23,12 @@
         <InternalsVisibleTo Include="Loretta.CodeAnalysis.Lua.Experimental" />
     </ItemGroup>
 
-    <ItemGroup>
+    <!-- Packages that we need from .NET 6+ on .NET Standard 2.0 -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Tsu" Version="2.2.2" />
     </ItemGroup>
 

--- a/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
+++ b/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;$(TargetFrameworks)</TargetFrameworks>
+        <TargetFrameworks>net6.0;$(TargetFrameworks)</TargetFrameworks>
         <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net6.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
+++ b/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;netstandard2.0;net472</TargetFrameworks>
         <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net6.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/src/InternalBenchmarks/Loretta.InternalBenchmarks.csproj
+++ b/src/InternalBenchmarks/Loretta.InternalBenchmarks.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>


### PR DESCRIPTION
.NET Core 3.1 has hit EOL therefore we no longer have a reason to support it.