### PR TITLE
Fix invalid escapes not working in cases where \z, \x and \u is used

### DIFF
--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -89,7 +89,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                                 break;
 
                             case 'z':
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptWhitespaceEscape)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && !_options.SyntaxOptions.AcceptWhitespaceEscape)
                                     goto default;
 
                                 TextWindow.AdvanceChar();
@@ -120,7 +120,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'x':
                             {
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptHexEscapesInStrings)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && !_options.SyntaxOptions.AcceptHexEscapesInStrings)
                                     goto default;
 
                                 TextWindow.AdvanceChar();
@@ -135,7 +135,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'u':
                             {
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptUnicodeEscape)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && !_options.SyntaxOptions.AcceptUnicodeEscape)
                                     goto default;
                                     
                                 TextWindow.AdvanceChar();

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -89,6 +89,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                                 break;
 
                             case 'z':
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                    goto default;
+
                                 TextWindow.AdvanceChar();
 
                                 while (CharUtils.IsWhitespace(TextWindow.PeekChar()))
@@ -117,6 +120,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'x':
                             {
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                    goto default;
+
                                 TextWindow.AdvanceChar();
                                 var parsedCharInteger = parseHexadecimalEscapeInteger(escapeStart);
                                 if (parsedCharInteger != char.MaxValue)
@@ -129,6 +135,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'u':
                             {
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                    goto default;
+                                    
                                 TextWindow.AdvanceChar();
                                 var parsed = parseUnicodeEscape(escapeStart);
                                 _builder.Append(parsed);

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -89,7 +89,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                                 break;
 
                             case 'z':
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptWhitespaceEscape)
                                     goto default;
 
                                 TextWindow.AdvanceChar();
@@ -120,7 +120,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'x':
                             {
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptHexEscapesInStrings)
                                     goto default;
 
                                 TextWindow.AdvanceChar();
@@ -135,7 +135,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'u':
                             {
-                                if (_options.SyntaxOptions.AcceptInvalidEscapes)
+                                if (_options.SyntaxOptions.AcceptInvalidEscapes && _options.SyntaxOptions.AcceptUnicodeEscape)
                                     goto default;
                                     
                                 TextWindow.AdvanceChar();

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -338,8 +338,8 @@ fourth line \xFF.";
 
             yield return new ShortToken(
                 SyntaxKind.HashStringLiteralToken,
-                    $"`{shortStringContentText}`",
-                    Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
+                $"`{shortStringContentText}`",
+                Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.ToLowerInvariant().AsSpan()));
 
             #endregion Strings
 

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Numerics;
+using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.CodeAnalysis.Text;
 using static Tsu.Option;
@@ -285,17 +286,28 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
 
             #region Strings
 
-            string shortStringContentText;
-            string shortStringContentValue;
+            var shortStringContentText = "hi\\n\\r\\b\\f\\n\\v\\u{D800}\\u{10FFFF}\\xF\\xFF\\z ";
+            var shortStringContentValue = "hi\n\r\b\f\n\vu{D800}u{10FFFF}xFxFFz ";
+
+            if (options.AcceptHexEscapesInStrings)
+            {
+                shortStringContentValue = shortStringContentValue.Replace("xFxFF", "\xF\xFF");
+            } 
+
+            if (options.AcceptUnicodeEscape)
+            {
+                shortStringContentValue = shortStringContentValue.Replace("u{D800}u{10FFFF}", "\uD800\U0010FFFF");
+            }
+
+            if (options.AcceptWhitespaceEscape)
+            {
+                shortStringContentValue = shortStringContentValue.Replace("z ", "");
+            }
 
             if (options.AcceptInvalidEscapes)
             {
-                shortStringContentText = "hi\\n\\r\\b\\f\\n\\v\\u{D800}\\u{10FFFF}\\xF\\xFF";
-                shortStringContentValue = "hi\n\r\b\f\n\vu{D800}u{10FFFF}xFxFF";
-            } else
-            {
-                shortStringContentText = "hi\\n\\r\\b\\f\\n\\v\\u{D800}\\u{10FFFF}\\xF\\xFF";
-                shortStringContentValue = "hi\n\r\b\f\n\v\uD800\U0010FFFF\xF\xFF";
+                shortStringContentText += "\\l";
+                shortStringContentValue += "l";
             }
 
             // Short strings
@@ -324,14 +336,10 @@ fourth line \xFF.";
                     longStringContent);
             }
 
-            if (!options.AcceptInvalidEscapes)
-            {
-                yield return new ShortToken(
-                    SyntaxKind.HashStringLiteralToken,
-                        $"`{shortStringContentText}`",
-                        Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
-            }
-
+            yield return new ShortToken(
+                SyntaxKind.HashStringLiteralToken,
+                    $"`{shortStringContentText}`",
+                    Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
 
             #endregion Strings
 

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -285,10 +285,18 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
 
             #region Strings
 
-            const string shortStringContentText = "hi\\\n\\\r\\\r\n\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"\\0\\10"
-                + "\\255\\xF\\xFF\\z    \t\t\r\n\\t\\r\\n\\u{F}\\u{FF}\\u{FFF}\\u{D800}\\u{10FFFF}";
-            const string shortStringContentValue = "hi\n\r\r\n\a\b\f\n\r\t\v\\'\"\0\xA"
-                + "\xFF\xF\xFF\t\r\n\u000F\u00FF\u0FFF\uD800\U0010FFFF";
+            string shortStringContentText;
+            string shortStringContentValue;
+
+            if (options.AcceptInvalidEscapes)
+            {
+                shortStringContentText = "hi\\n\\r\\b\\f\\n\\v\\u{D800}\\u{10FFFF}\\xF\\xFF";
+                shortStringContentValue = "hi\n\r\b\f\n\vu{D800}u{10FFFF}xFxFF";
+            } else
+            {
+                shortStringContentText = "hi\\n\\r\\b\\f\\n\\v\\u{D800}\\u{10FFFF}\\xF\\xFF";
+                shortStringContentValue = "hi\n\r\b\f\n\v\uD800\U0010FFFF\xF\xFF";
+            }
 
             // Short strings
             foreach (var quote in new[] { '\'', '"' })
@@ -316,10 +324,14 @@ fourth line \xFF.";
                     longStringContent);
             }
 
-            yield return new ShortToken(
-                SyntaxKind.HashStringLiteralToken,
-                $"`{shortStringContentText}`",
-                Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
+            if (!options.AcceptInvalidEscapes)
+            {
+                yield return new ShortToken(
+                    SyntaxKind.HashStringLiteralToken,
+                        $"`{shortStringContentText}`",
+                        Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
+            }
+
 
             #endregion Strings
 


### PR DESCRIPTION
Fixes a bug where having `AcceptInvalidEscapes` would not properly work and parse/produce errors incorrectly.

**Reproduction case**
```lua
print((bit or bit32)["b\xor"])
```