### PR TITLE
Fix single line comments not getting line breaks after them when normalizing whitespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed `LuaSyntaxOptions.AcceptInvalidEscapes` not suppressing errors in cases where `LuaSyntaxOptions.{AcceptWhitespaceEscape,AcceptHexEscapesInStrings,AcceptUnicodeEscape}` were `false` by @TheGreatSageEqualToHeaven in https://github.com/LorettaDevs/Loretta/pull/116.
+- Fixed single line comments not getting a line break added after them in `NormalizeWhitespace` by @GGG-KILLER in https://github.com/LorettaDevs/Loretta/pull/118.
 
 ### Removed
 - Removed `LanguageNames.{CSharp,FSharp,VisualBasic}` by @GGG-KILLER in https://github.com/LorettaDevs/Loretta/pull/115.

--- a/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Syntax/SyntaxNormalizerTests.cs
@@ -1234,6 +1234,79 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests
             AssertNormalizeCore(root, "print(1, 2)");
         }
 
+        [Theory]
+        [WorkItem(117, "https://github.com/LorettaDevs/Loretta/issues/117")]
+        [InlineData("""
+                    string_format(
+                        "%s %s",
+                        "test", -- comment here
+                        "test2"
+                    )
+                    """,
+                    """
+                    string_format("%s %s", "test", -- comment here
+                    "test2")
+                    """)]
+        [InlineData("""
+                    string_format(
+                        "test", -- comment here
+                        "%s %s",
+                        "test2"
+                    )
+                    """,
+                    """
+                    string_format("test", -- comment here
+                    "%s %s", "test2")
+                    """)]
+        [InlineData("""
+                    string_format(
+                        "%s %s",
+                        "test2",
+                        "test" -- comment here
+                    )
+                    """,
+                    """
+                    string_format("%s %s", "test2", "test" -- comment here
+                    )
+                    """)]
+        [InlineData("""
+                    string_format(
+                        "%s %s",
+                        "test", --[[ comment here ]]
+                        "test2"
+                    )
+                    """,
+                    """
+                    string_format("%s %s", "test", --[[ comment here ]] "test2")
+                    """)]
+        [InlineData("""
+                    string_format(
+                        "test", --[[ comment here ]]
+                        "%s %s",
+                        "test2"
+                    )
+                    """,
+                    """
+                    string_format("test", --[[ comment here ]] "%s %s", "test2")
+                    """)]
+        [InlineData("""
+                    string_format(
+                        "%s %s",
+                        "test2",
+                        "test" --[[ comment here ]]
+                    )
+                    """,
+                    """
+                    string_format("%s %s", "test2", "test" --[[ comment here ]])
+                    """)]
+        public void SyntaxNormalizer_CorrectlyAddsLineBreaksAfterSingleLineComments(string input, string expected)
+        {
+            var tree = ParseAndValidate(input, s_luaParseOptions);
+            var root = tree.GetRoot();
+
+            AssertNormalizeCore(root, expected);
+        }
+
         #region Class Implementation Details
 
         private static void AssertNormalizeCore(SyntaxNode node, string expected)


### PR DESCRIPTION
This happened because we had a check where line breaks weren't added if the comment was located inside trailing trivia.

I've changed it to always add line breaks after them and also ignore the add separator flag if the last trivia for the token is already a whitespace or a line break.

Fixes #117.