### PR TITLE
Fix Luau not having floor division enabled.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- **[Breaking]** `LuaSyntaxOptions.Luau` has been modified to enable floor division by @GGG-KILLER in https://github.com/LorettaDevs/Loretta/pull/133.
+
 ## v0.2.12
 ### Fixed
 - Fixed `LuaSyntaxOptions.AcceptInvalidEscapes` not suppressing errors in cases where `LuaSyntaxOptions.{AcceptWhitespaceEscape,AcceptHexEscapesInStrings,AcceptUnicodeEscape}` were `false` by @TheGreatSageEqualToHeaven in https://github.com/LorettaDevs/Loretta/pull/116.

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -39,7 +39,7 @@ namespace Loretta.CodeAnalysis
         //       It appears that in all cases so far we considered isDefaultValue, and not about value being 
         //       arithmetic zero (especially when definition is ambiguous).
 
-        public const ConstantValue NotAvailable = null;
+        public const ConstantValue? NotAvailable = null;
 
         public static ConstantValue Bad => ConstantValueBad.Instance;
         public static ConstantValue Nil => ConstantValueNil.Instance;

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -152,7 +152,7 @@ namespace Loretta.CodeAnalysis.Lua
             // Luau parses hex as a long and then converts it to a double
             hexIntegerFormat: IntegerFormats.Double,
             acceptTypedLua: true,
-            acceptFloorDivision: false,
+            acceptFloorDivision: true,
             acceptLuaJITNumberSuffixes: false,
             acceptNestingOfLongStrings: true);
 


### PR DESCRIPTION
Luau had floor division added sometime mid-last year, update the `LuaSyntaxOptions.Luau` to reflect that.