### PR TITLE
Properly disable continue, goto and goto labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,22 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [UNRELEASED]
+
+### Changed
+
+- Identifier tokens now never have a `ContextualKind` by @GGG-KILLER in https://github.com/LorettaDevs/Loretta/pull/134.
+
+### Fixed
+
+- Fixed `continue` still being parsed as a keyword even when `ContinueType` was `ContinueType.None` by @GGG-KILLER
+  in https://github.com/LorettaDevs/Loretta/pull/134;
+- Fixed `goto` and `::label::` still being parsed when `AcceptGoto` was `false` by @GGG-KILLER in
+  https://github.com/LorettaDevs/Loretta/pull/134.
 
 ## v0.2.12
 ### Fixed

--- a/src/Compilers/Lua/Portable/Parser/Lexer.Identifiers.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.Identifiers.cs
@@ -6,7 +6,8 @@
         {
             if (ScanIdentifier(ref info))
             {
-                if (!_cache.TryGetKeywordKind(info.Text!, out info.Kind))
+                if (!_cache.TryGetKeywordKind(info.Text!, out info.Kind)
+                    || SyntaxFacts.HasKeywordBeenDisabled(info.Kind, _options.SyntaxOptions))
                 {
                     info.ContextualKind = info.Kind = SyntaxKind.IdentifierToken;
                 }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.Identifiers.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.Identifiers.cs
@@ -9,16 +9,16 @@
                 if (!_cache.TryGetKeywordKind(info.Text!, out info.Kind)
                     || SyntaxFacts.HasKeywordBeenDisabled(info.Kind, _options.SyntaxOptions))
                 {
-                    info.ContextualKind = info.Kind = SyntaxKind.IdentifierToken;
+                    info.ContextualKind = SyntaxKind.None;
+                    info.Kind           = SyntaxKind.IdentifierToken;
                 }
                 else if (SyntaxFacts.IsContextualKeyword(info.Kind, _options.SyntaxOptions))
                 {
                     info.ContextualKind = info.Kind;
-                    info.Kind = SyntaxKind.IdentifierToken;
+                    info.Kind           = SyntaxKind.IdentifierToken;
                 }
 
-                if (info.Kind is SyntaxKind.None)
-                    info.Kind = SyntaxKind.IdentifierToken;
+                if (info.Kind is SyntaxKind.None) info.Kind = SyntaxKind.IdentifierToken;
 
                 return true;
             }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -244,7 +244,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                 case ':':
                     TextWindow.AdvanceChar();
-                    if (TextWindow.PeekChar() == ':')
+                    if (_options.SyntaxOptions.AcceptGoto && TextWindow.PeekChar() == ':')
                     {
                         TextWindow.AdvanceChar();
                         info.Kind = SyntaxKind.ColonColonToken;

--- a/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Loretta.CodeAnalysis.Lua.SyntaxFacts.HasKeywordBeenDisabled(Loretta.CodeAnalysis.Lua.SyntaxKind kind, Loretta.CodeAnalysis.Lua.LuaSyntaxOptions! syntaxOptions) -> bool

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
@@ -49,6 +49,7 @@ namespace Loretta.CodeAnalysis.Lua
             => kind switch
             {
                 SyntaxKind.ContinueKeyword => syntaxOptions.ContinueType == ContinueType.None,
+                SyntaxKind.GotoKeyword     => !syntaxOptions.AcceptGoto,
                 _                          => false,
             };
 

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
@@ -40,6 +40,19 @@ namespace Loretta.CodeAnalysis.Lua
             };
 
         /// <summary>
+        /// Checks whether a keyword has been disabled by the <paramref name="syntaxOptions"/>.
+        /// </summary>
+        /// <param name="kind">The keyword's <see cref="SyntaxKind"/>.</param>
+        /// <param name="syntaxOptions">The <see cref="LuaSyntaxOptions"/> to check against.</param>
+        /// <returns></returns>
+        public static bool HasKeywordBeenDisabled(SyntaxKind kind, LuaSyntaxOptions syntaxOptions)
+            => kind switch
+            {
+                SyntaxKind.ContinueKeyword => syntaxOptions.ContinueType == ContinueType.None,
+                _                          => false,
+            };
+
+        /// <summary>
         /// Checks whether a given kind is a contextual keyword.
         /// </summary>
         /// <param name="kind"></param>

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -31,12 +31,15 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
 
         public static IEnumerable<ShortToken> GetTokens(LuaSyntaxOptions options)
         {
-            foreach (var token in from kind in Enum.GetValues(typeof(SyntaxKind))
-                                                   .Cast<SyntaxKind>()
+#pragma warning disable CA2263 (Unavailable in .NET Framework)
+            foreach (var token in from kind in Enum.GetValues(typeof(SyntaxKind)).Cast<SyntaxKind>()
+#pragma warning restore CA2263 (Unavailable in .NET Framework)
                                   where !SyntaxFacts.IsManufacturedToken(kind, options)
+                                        && !SyntaxFacts.HasKeywordBeenDisabled(kind, options)
+                                        && (kind != SyntaxKind.ColonColonToken || options.AcceptGoto)
+                                        && (kind != SyntaxKind.SlashSlashToken || options.AcceptFloorDivision)
                                   let text = SyntaxFacts.GetText(kind)
                                   where !string.IsNullOrEmpty(text)
-                                    && (text != "//" || options.AcceptFloorDivision)
                                   select new ShortToken(kind, text))
             {
                 yield return token;
@@ -363,6 +366,10 @@ fourth line \xFF.";
             {
                 yield return new ShortToken(SyntaxKind.IdentifierToken, identifier);
             }
+
+            if (options.ContinueType == ContinueType.None)
+                yield return new ShortToken(SyntaxKind.IdentifierToken, "continue");
+            if (!options.AcceptGoto) yield return new ShortToken(SyntaxKind.IdentifierToken, "goto");
         }
 
         public static IEnumerable<ShortToken> GetTrivia(LuaSyntaxOptions options)

--- a/src/Compilers/Lua/Test/Portable/Lexical/RegressionTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/RegressionTests.cs
@@ -95,5 +95,35 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
                 (SyntaxKind.EndOfFileToken, SyntaxKind.EndOfFileToken),
             ], tokens);
         }
+
+        // This didn't exactly come from this issue, but it was another keyword that didn't have this handling.
+        [Fact]
+        [WorkItem(127, "https://github.com/LorettaDevs/Loretta/issues/127")]
+        [Trait("Type", TestType.Regression)]
+        [Trait("Category", "Lexer/Diagnostics")]
+        public void Lexer_DoesNotLexGotoAsKeywordWhenItHasBeenDisabled()
+        {
+            const string RawText = """
+                                   ::label::
+
+                                   goto label
+                                   """;
+
+            var tokens = Lex(RawText, LuaSyntaxOptions.Lua51).Select(static t => (t.Kind(), t.ContextualKind()));
+            
+            Assert.Equal([
+                // ::label::
+                (SyntaxKind.ColonToken, SyntaxKind.ColonToken),
+                (SyntaxKind.ColonToken, SyntaxKind.ColonToken),
+                (SyntaxKind.IdentifierToken, SyntaxKind.None),
+                (SyntaxKind.ColonToken, SyntaxKind.ColonToken),
+                (SyntaxKind.ColonToken, SyntaxKind.ColonToken),
+                
+                // goto label
+                (SyntaxKind.IdentifierToken, SyntaxKind.None),
+                (SyntaxKind.IdentifierToken, SyntaxKind.None),
+                (SyntaxKind.EndOfFileToken, SyntaxKind.EndOfFileToken),
+            ], tokens);
+        }
     }
 }

--- a/src/Compilers/Lua/Test/Portable/Parsing/RegressionTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/RegressionTests.cs
@@ -152,5 +152,109 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Parsing
                 // (1,13): error LUA0021: Bitwise operators are not supported in this lua version
                 // local x = y | z
                 Diagnostic(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion, "|").WithLocation(1, 13));
+
+        [Fact, WorkItem(127, "https://github.com/LorettaDevs/Loretta/issues/127")]
+        public void LanguageParser_ProperlyTreatsContinueAsNormalIdentifierWhenContinueTypeIsNone()
+        {
+            var initial = ParseWithRoundTripCheck(
+                """
+                local continue = true
+
+                if continue then
+                    continue = false
+                end
+                """,
+                new LuaParseOptions(LuaSyntaxOptions.Lua51));
+
+            UsingNode((LuaSyntaxNode) initial.GetRoot());
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.StatementList);
+                {
+                    N(SyntaxKind.LocalVariableDeclarationStatement);
+                    {
+                        N(SyntaxKind.LocalKeyword);
+                        N(SyntaxKind.LocalDeclarationName);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "continue");
+                            }
+                            N(SyntaxKind.EqualsValuesClause);
+                            {
+                                N(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.TrueLiteralExpression);
+                                {
+                                    N(SyntaxKind.TrueKeyword);
+                                }
+                            }
+                        }
+                    }
+
+                    N(SyntaxKind.IfStatement);
+                    {
+                        N(SyntaxKind.IfKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "continue");
+                        }
+                        N(SyntaxKind.ThenKeyword);
+
+                        N(SyntaxKind.StatementList);
+                        {
+                            N(SyntaxKind.AssignmentStatement);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "continue");
+                                }
+                                
+                                N(SyntaxKind.EqualsValuesClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.FalseLiteralExpression);
+                                    {
+                                        N(SyntaxKind.FalseKeyword);
+                                    }
+                                }
+                            }
+                        }
+
+                        N(SyntaxKind.EndKeyword);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+        
+        [Fact, WorkItem(127, "https://github.com/LorettaDevs/Loretta/issues/127")]
+        public void LanguageParser_DoesNotFindGotosNorGotoLabelsWhenAcceptGotoIsNotTrue() =>
+            ParseAndValidate("::label:: goto label", LuaSyntaxOptions.Lua51,
+                // (1,1): error LUA1012: Invalid statement
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_InvalidStatement, ":").WithLocation(1, 1),
+                // (1,2): error LUA1012: Invalid statement
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_InvalidStatement, ":labe").WithLocation(1, 2),
+                // (1,9): error LUA1001: Identifier expected
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 9),
+                // (1,9): error LUA1006: Syntax error, '(' expected
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("(", ":").WithLocation(1, 9),
+                // (1,9): error LUA1011: Invalid expression part ':'
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_InvalidExpressionPart, ":").WithArguments(":").WithLocation(1, 9),
+                // (1,9): error LUA1003: ) expected
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 9),
+                // (1,16): error LUA1006: Syntax error, '(' expected
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_SyntaxError, "label").WithArguments("(", "").WithLocation(1, 16),
+                // (1,21): error LUA1003: ) expected
+                // ::label:: goto label
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 21));
+        
     }
 }


### PR DESCRIPTION
This PR changes the Lexer to properly lex `continue` and `goto` as identifier tokens instead of keywords when their flags aren't on and disables handling of `::` tokens if the `AllowGoto` flag is not set.

Fixes #127.